### PR TITLE
Fix incorrect ESM exports field for Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "exports": {
     "./tsl-textures.js": {
       "require": "./dist/cjs/tsl-textures.js",
-      "import": "./dist/esm/tsl-textures.js"
+      "import": "./dist/tsl-textures.js"
     }
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "./tsl-textures.js": {
       "require": "./dist/cjs/tsl-textures.js",
       "import": "./dist/tsl-textures.js"
+    },
+    ".": {
+      "require": "./dist/cjs/tsl-textures.js",
+      "import": "./dist/tsl-textures.js"
     }
   },
   "repository": {


### PR DESCRIPTION
In #17, there was probably the following error.
> Failed to resolve entry for package "tsl-textures". The package may have incorrect main/module/exports specified in its package.json: Missing "." specifier in "tsl-textures" package

This is an error that occurs in code like the following:
```js
import { ... } from "tsl-textures";
```

To deal with this, I added `.` to the `exports` field. Also, I fixed the `./tsl-textures.ts` property which had the wrong export source for ESM.