### PR TITLE
Add type declarations, tests for types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  types:
+    name: Type check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,24 @@
         "@rollup/plugin-commonjs": "^28.0.3",
         "@rollup/plugin-node-resolve": "^16.0.1",
         "@rollup/plugin-terser": "^0.4.4",
+        "@types/three": "^0.184.1",
         "eslint": "^9.4.0",
         "eslint-plugin-html": "^8.1.1",
         "globals": "^15.15.0",
-        "rollup": "^4.37.0"
+        "rollup": "^4.37.0",
+        "three": "^0.184.0",
+        "typescript": "^5.9.3"
+      },
+      "peerDependencies": {
+        "three": ">=0.183.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.5.1",
@@ -641,6 +654,13 @@
         "win32"
       ]
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -660,11 +680,41 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.184.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.1.tgz",
+      "integrity": "sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -935,6 +985,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.23.0.tgz",
       "integrity": "sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1128,6 +1179,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -1443,6 +1501,13 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -1557,6 +1622,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1627,6 +1693,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.37.0.tgz",
       "integrity": "sha512-iAtQy/L4QFU+rTJ1YUjXqJOJzuwEghqWzCEYD2FEghT7Gsy1VdABntrO4CLopA5IkflTyqNiLNwPcOJ3S7UKLg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -1803,6 +1870,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -1813,6 +1887,20 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -4,12 +4,15 @@
   "description": "A collection of Three.js Shading Language (TSL) textures ",
   "main": "./src/tsl-textures.js",
   "module": "./src/tsl-textures.js",
+  "types": "./src/tsl-textures.d.ts",
   "exports": {
     "./tsl-textures.js": {
+      "types": "./src/tsl-textures.d.ts",
       "require": "./dist/cjs/tsl-textures.js",
       "import": "./dist/tsl-textures.js"
     },
     ".": {
+      "types": "./src/tsl-textures.d.ts",
       "require": "./dist/cjs/tsl-textures.js",
       "import": "./dist/tsl-textures.js"
     }
@@ -20,7 +23,8 @@
   },
   "scripts": {
     "build": "rollup -c",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npm run test:types",
+    "test:types": "tsc --noEmit -p tsconfig.json"
   },
   "keywords": [
     "texture",
@@ -37,14 +41,20 @@
     "src"
   ],
   "license": "MIT",
+  "peerDependencies": {
+    "three": ">=0.183.0"
+  },
   "devDependencies": {
     "@eslint/js": "^9.4.0",
     "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-terser": "^0.4.4",
+    "@types/three": "^0.184.1",
     "eslint": "^9.4.0",
     "eslint-plugin-html": "^8.1.1",
     "globals": "^15.15.0",
-    "rollup": "^4.37.0"
+    "rollup": "^4.37.0",
+    "three": "^0.184.0",
+    "typescript": "^5.9.3"
   }
 }

--- a/src/tsl-textures-tests.ts
+++ b/src/tsl-textures-tests.ts
@@ -1,0 +1,191 @@
+// Type tests for tsl-textures, in the style used by DefinitelyTyped.
+//
+// This file is never executed; it is only type-checked (see tsconfig.json).
+// It exercises the public API surface declared in tsl-textures.d.ts so that
+// `tsc --noEmit` fails if the declarations drift away from the runtime API.
+
+import { Color, Node, Vector2, Vector3 } from "three/webgpu";
+import { float, vec2, vec3 } from "three/tsl";
+
+import {
+	// utility functions
+	approximateNormal,
+	hideFallbackWarning,
+	hsl,
+	remapExp,
+	rotatePivot,
+	selectPlanar,
+	showFallbackWarning,
+	spherical,
+	toHsl,
+	vnoise,
+
+	// re-exported noise / fractal / voronoi
+	fractal,
+	fractal3,
+	noise,
+	noise3,
+	voronoi,
+	voronoi2,
+	voronoi3,
+
+	// simple textures (callable + .defaults)
+	bricks,
+	camouflage,
+	grid,
+	halftone,
+	planet,
+	polkaDots,
+
+	// multi-channel textures
+	brain,
+	clouds,
+	rotator,
+	runnyEggs,
+	rust,
+	scaler,
+	supersphere,
+	translator,
+	waves,
+
+	// param interfaces
+	BricksParams,
+	GridParams,
+	HalftoneParams,
+	RunnyEggsParams,
+} from "tsl-textures";
+
+// Asserts that `value` is assignable to `T`. Used instead of typed `const`
+// bindings so the file produces no "unused variable" noise under strict configs.
+declare function expectType<T>(value: T): void;
+
+// Sample node values of each supported kind, used as inputs below.
+const f: Node<"float"> = float(1);
+const v2node: Node<"vec2"> = vec2(0, 1);
+const v3node: Node<"vec3"> = vec3(0, 1, 2);
+
+const col = new Color(0xff0000);
+const p2 = new Vector2(0.5, 0.5);
+const p3 = new Vector3(0, 1, 0);
+
+// === Utility functions ===
+
+expectType<Node<"vec3">>(approximateNormal(v3node, p3, v3node));
+
+// remapExp: float-ish args (numbers or float nodes) -> float node.
+expectType<Node<"float">>(remapExp(0.5, 0, 1, 1, 10));
+expectType<Node<"float">>(remapExp(f, f, 1, 0, f));
+
+// hsl / toHsl convert vec3 <-> vec3.
+expectType<Node<"vec3">>(hsl(v3node));
+expectType<Node<"vec3">>(toHsl(p3));
+
+expectType<Node<"vec3">>(rotatePivot(v3node, p3, v3node));
+expectType<Node<"float">>(vnoise(v3node));
+expectType<Node<"vec3">>(spherical(f, 0.25));
+expectType<Node<"float">>(selectPlanar(v3node, p2, p3, 0.5));
+
+// Fallback-warning helpers.
+expectType<Promise<void>>(showFallbackWarning());
+hideFallbackWarning();
+
+// === Re-exported noise functions ===
+// These come straight from three/tsl; just confirm they are exported and callable.
+noise(v3node);
+noise3(v3node);
+fractal(v3node);
+fractal3(v3node);
+voronoi(v3node);
+voronoi2(v3node);
+voronoi3(v3node);
+
+// === Simple textures ===
+
+// Callable with no arguments.
+expectType<Node<"vec3">>(bricks());
+
+// Partial params; F accepts numbers or float nodes, C accepts Color or color
+// nodes, V3 accepts Vector3 or vec3 nodes.
+expectType<Node<"vec3">>(
+	bricks({ scale: 2, brickSize: p3, jointSize: f, color: col, seed: 7 }),
+);
+
+// camouflage exposes several color slots.
+camouflage({ colorA: col, colorB: col, colorC: col, colorD: col, seed: 1 });
+
+// grid uses uv (vec2) inputs and a boolean flag.
+expectType<Node<"vec3">>(
+	grid({ uvs: v2node, countU: 32, countV: 16, equirectangular: true, color: col }),
+);
+
+// halftone uses a vec2 position and accepts a vec3 OR color for `color`.
+halftone({ position: p2, radius: 0.5, color: v3node });
+halftone({ position: vec2(0, 0), color: col, positionView: p3 });
+
+// planet has many balance/color knobs.
+planet({ iterations: 10, levelSea: 0.5, colorDeep: col, colorSnow: col });
+
+// polkaDots uses a `flat` flag-like float.
+polkaDots({ count: 4, size: 0.3, blur: f, flat: 1 });
+
+// `.defaults` is exposed and shaped like the params object.
+expectType<BricksParams>(bricks.defaults);
+expectType<GridParams>(grid.defaults);
+expectType<HalftoneParams>(halftone.defaults);
+
+// === Textures with a .normal() channel ===
+
+expectType<Node<"vec3">>(brain({ color: col, background: col }));
+expectType<Node<"vec3">>(brain.normal({ wave: 0.5, speed: 2.5, time: f }));
+
+// rotator / scaler / translator / supersphere share params across channels.
+rotator.normal({ angles: p3, center: p3, selectorWidth: 0.5 });
+scaler.normal({ scales: p3, selectorAngles: p2 });
+translator.normal({ distance: p3, selectorCenter: p3 });
+supersphere.normal({ exponent: 3 });
+
+// === Textures with an .opacity() channel ===
+
+expectType<Node<"vec3">>(clouds({ density: 0.5, color: col, subcolor: col }));
+expectType<Node<"float">>(clouds.opacity({ density: 0.5, opacity: 0.8 }));
+
+expectType<Node<"float">>(rust.opacity({ amount: 0.5, opacity: 0.5 }));
+expectType<Node<"float">>(waves.opacity({ level: 0.5, foamEdge: 0.1 }));
+
+// The same config object can be fed to every channel of a texture.
+const cloudConfig = { scale: 3, density: 0.7, opacity: 0.8, color: col, seed: 5 };
+expectType<Node<"vec3">>(clouds(cloudConfig));
+expectType<Node<"float">>(clouds.opacity(cloudConfig));
+
+// === runnyEggs: both .normal() and .roughness() ===
+
+expectType<Node<"vec3">>(runnyEggs({ sizeYolk: 0.2, sizeWhite: 0.7, colorYolk: col }));
+expectType<Node<"vec3">>(runnyEggs.normal({ sizeWhite: 0.7 }));
+expectType<Node<"float">>(runnyEggs.roughness({ sizeYolk: 0.2 }));
+
+// The full params object is the superset and works on every channel.
+const eggConfig: RunnyEggsParams = { sizeYolk: 0.2, sizeWhite: 0.7, colorWhite: col };
+runnyEggs(eggConfig);
+runnyEggs.normal(eggConfig);
+runnyEggs.roughness(eggConfig);
+
+// === Negative tests ===
+
+// A simple texture has no extra channels.
+// @ts-expect-error - bricks is a plain texture without a .normal() method.
+bricks.normal();
+
+// @ts-expect-error - clouds has .opacity(), not .normal().
+clouds.normal();
+
+// @ts-expect-error - scale must be a number or float node, not a string.
+brain({ scale: "large" });
+
+// @ts-expect-error - `nope` is not a known parameter.
+grid({ nope: true });
+
+// @ts-expect-error - a color slot does not accept a bare number.
+camouflage({ colorA: 123 });
+
+// @ts-expect-error - bricks() returns a vec3, not a float.
+expectType<Node<"float">>(bricks());

--- a/src/tsl-textures.d.ts
+++ b/src/tsl-textures.d.ts
@@ -1,0 +1,656 @@
+import type { Color, Node, Vector2, Vector3 } from 'three/webgpu';
+
+// Parameter input aliases. Each texture passes its params straight into a TSL Fn
+// (via setLayout), which coerces every argument — so a param typed with one of
+// these accepts either a plain JS value or a TSL node of that type (e.g. a
+// uniform() or an animated time node), letting the texture be configured
+// statically or driven by a node graph. The plain boolean flags (e.g.
+// GridParams.equirectangular) are the exception and stay JS booleans.
+type FloatInput = Node<'float'> | number;
+type Vec2Input = Node<'vec2'> | Vector2;
+type Vec3Input = Node<'vec3'> | Vector3;
+type ColorInput = Node<'color'> | Color;
+
+// === Utility functions ===
+
+export declare function approximateNormal(pos: Vec3Input, posU: Vec3Input, posV: Vec3Input): Node<'vec3'>;
+export declare function showFallbackWarning(): Promise<void>;
+export declare function hideFallbackWarning(): void;
+export declare function remapExp(x: FloatInput, fromMin: FloatInput, fromMax: FloatInput, toMin: FloatInput, toMax: FloatInput): Node<'float'>;
+export declare function hsl(col: Vec3Input): Node<'vec3'>;
+export declare function toHsl(rgb: Vec3Input): Node<'vec3'>;
+export declare function rotatePivot(vector: Vec3Input, pivot: Vec3Input, angle: Vec3Input): Node<'vec3'>;
+export declare function vnoise(v: Vec3Input): Node<'float'>;
+export declare function spherical(phi: FloatInput, theta: FloatInput): Node<'vec3'>;
+export declare function selectPlanar(pos: Vec3Input, selAngles: Vec2Input, selCenter: Vec3Input, selWidth: FloatInput): Node<'float'>;
+
+// Noise / fractal / voronoi re-exported from three/tsl
+export {
+	mx_noise_float as noise,
+	mx_noise_vec3 as noise3,
+	mx_fractal_noise_float as fractal,
+	mx_fractal_noise_vec3 as fractal3,
+	mx_worley_noise_float as voronoi,
+	mx_worley_noise_vec2 as voronoi2,
+	mx_worley_noise_vec3 as voronoi3,
+} from 'three/tsl';
+
+// === Texture param interfaces ===
+
+export interface BrainParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	smooth?: FloatInput;
+	wave?: FloatInput;
+	speed?: FloatInput;
+	time?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface BricksParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	brickSize?: Vec3Input;
+	brickShift?: FloatInput;
+	jointSize?: FloatInput;
+	jointSpan?: FloatInput;
+	jointJitter?: FloatInput;
+	jointBlur?: FloatInput;
+	noiseSize?: FloatInput;
+	noiseStrength?: FloatInput;
+	colorShade?: FloatInput;
+	color?: ColorInput;
+	additional?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface CamouflageParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	colorA?: ColorInput;
+	colorB?: ColorInput;
+	colorC?: ColorInput;
+	colorD?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface CausticsParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	speed?: FloatInput;
+	time?: FloatInput;
+	color?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface CaveArtParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	thinness?: FloatInput;
+	noise?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface CircleDecorParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	grains?: FloatInput;
+	complexity?: FloatInput;
+	blur?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface CirclesParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	variety?: FloatInput;
+	color?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface CloudsParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	density?: FloatInput;
+	opacity?: FloatInput;
+	color?: ColorInput;
+	subcolor?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface ConcreteParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	density?: FloatInput;
+	bump?: FloatInput;
+	seed?: FloatInput;
+}
+
+export interface CorkParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	straight?: FloatInput;
+	noise?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface CrumpledFabricParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	pinch?: FloatInput;
+	color?: ColorInput;
+	subcolor?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface DalmatianSpotsParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	density?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface DarthMaulParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	shift?: Vec3Input;
+	complexity?: FloatInput;
+	angle?: FloatInput;
+	distance?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	balance?: FloatInput;
+	seed?: FloatInput;
+}
+
+export interface DysonSphereParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	complexity?: FloatInput;
+	variation?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface EntangledParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	density?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface ForditeParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	color?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface GasGiantParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	turbulence?: FloatInput;
+	blur?: FloatInput;
+	colorA?: ColorInput;
+	colorB?: ColorInput;
+	colorC?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface GridParams {
+	uvs?: Vec2Input;
+	countU?: FloatInput;
+	countV?: FloatInput;
+	aspect?: FloatInput;
+	thinness?: FloatInput;
+	equirectangular?: boolean;
+	color?: ColorInput;
+	background?: ColorInput;
+}
+
+export interface HalftoneParams {
+	position?: Vec2Input;
+	scale?: FloatInput;
+	radius?: FloatInput;
+	pattern?: FloatInput;
+	attenuation?: FloatInput;
+	near?: FloatInput;
+	far?: FloatInput;
+	color?: Vec3Input | ColorInput;
+	positionView?: Vec3Input;
+}
+
+export interface IsolayersParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	layers?: FloatInput;
+	edge?: FloatInput;
+	darkness?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface IsolinesParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	density?: FloatInput;
+	blur?: FloatInput;
+	thinness?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface KarstRockParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface MarbleParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	thinness?: FloatInput;
+	noise?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface NeonLightsParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	thinness?: FloatInput;
+	mode?: FloatInput;
+	colorA?: ColorInput;
+	colorB?: ColorInput;
+	colorC?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface PerlinNoiseParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	balance?: FloatInput;
+	contrast?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface PhotosphereParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface PlanetParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	iterations?: FloatInput;
+	levelSea?: FloatInput;
+	levelMountain?: FloatInput;
+	balanceWater?: FloatInput;
+	balanceSand?: FloatInput;
+	balanceSnow?: FloatInput;
+	colorDeep?: ColorInput;
+	colorShallow?: ColorInput;
+	colorBeach?: ColorInput;
+	colorGrass?: ColorInput;
+	colorForest?: ColorInput;
+	colorSnow?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface PolkaDotsParams {
+	position?: Vec3Input;
+	count?: FloatInput;
+	size?: FloatInput;
+	blur?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	flat?: FloatInput;
+}
+
+export interface ProcessedWoodParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	lengths?: FloatInput;
+	strength?: FloatInput;
+	angle?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface ProtozoaParams {
+	position?: Vec3Input;
+	matcap?: Vec2Input;
+	scale?: FloatInput;
+	fat?: FloatInput;
+	amount?: FloatInput;
+	color?: ColorInput;
+	subcolor?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface ReticularVeinsParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	reticulation?: FloatInput;
+	strength?: FloatInput;
+	organelles?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface RomanPavingParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	depth?: FloatInput;
+	seed?: FloatInput;
+}
+
+export interface RotatorParams {
+	angles?: Vec3Input;
+	center?: Vec3Input;
+	selectorCenter?: Vec3Input;
+	selectorAngles?: Vec2Input;
+	selectorWidth?: FloatInput;
+}
+
+export interface RoughClayParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	bump?: FloatInput;
+	curvature?: FloatInput;
+	seed?: FloatInput;
+}
+
+export interface RunnyEggsParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	sizeYolk?: FloatInput;
+	sizeWhite?: FloatInput;
+	colorYolk?: ColorInput;
+	colorWhite?: ColorInput;
+	colorBackground?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface RustParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	iterations?: FloatInput;
+	amount?: FloatInput;
+	opacity?: FloatInput;
+	noise?: FloatInput;
+	noiseScale?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface SatinParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface ScalerParams {
+	scales?: Vec3Input;
+	center?: Vec3Input;
+	selectorCenter?: Vec3Input;
+	selectorAngles?: Vec2Input;
+	selectorWidth?: FloatInput;
+}
+
+export interface ScepterHeadParams {
+	position?: Vec3Input;
+	xFactor?: FloatInput;
+	yFactor?: FloatInput;
+	zFactor?: FloatInput;
+	colorRim?: ColorInput;
+	colorA?: ColorInput;
+	colorB?: ColorInput;
+}
+
+export interface ScreamParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	variety?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface StarsParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	density?: FloatInput;
+	variation?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface StaticNoiseParams {
+	position?: Vec2Input;
+	time?: FloatInput;
+	scale?: FloatInput;
+	balance?: FloatInput;
+	contrast?: FloatInput;
+	delay?: FloatInput;
+	seed?: FloatInput;
+}
+
+export interface SupersphereParams {
+	exponent?: FloatInput;
+}
+
+export interface TigerFurParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	lengths?: FloatInput;
+	blur?: FloatInput;
+	strength?: FloatInput;
+	hairs?: FloatInput;
+	color?: ColorInput;
+	bottomColor?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface TranslatorParams {
+	distance?: Vec3Input;
+	selectorCenter?: Vec3Input;
+	selectorAngles?: Vec2Input;
+	selectorWidth?: FloatInput;
+}
+
+export interface TurbulentSmokeParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	speed?: FloatInput;
+	details?: FloatInput;
+	time?: FloatInput;
+	seed?: FloatInput;
+}
+
+export interface VoronoiCellsParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	variation?: FloatInput;
+	facet?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface WaterDropsParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	density?: FloatInput;
+	bump?: FloatInput;
+	seed?: FloatInput;
+}
+
+export interface WatermelonParams {
+	position?: Vec3Input;
+	uvs?: Vec2Input;
+	scale?: FloatInput;
+	stripes?: FloatInput;
+	variation?: FloatInput;
+	noise?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface WavesParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	speed?: FloatInput;
+	time?: FloatInput;
+	level?: FloatInput;
+	rough?: FloatInput;
+	height?: FloatInput;
+	foamSize?: FloatInput;
+	foamEdge?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface WoodParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	rings?: FloatInput;
+	lengths?: FloatInput;
+	angle?: FloatInput;
+	fibers?: FloatInput;
+	fibersDensity?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	seed?: FloatInput;
+}
+
+export interface ZebraLinesParams {
+	position?: Vec3Input;
+	scale?: FloatInput;
+	thinness?: FloatInput;
+	phi?: FloatInput;
+	theta?: FloatInput;
+	color?: ColorInput;
+	background?: ColorInput;
+	flat?: FloatInput;
+}
+
+// === Texture function types ===
+
+// Simple texture: callable + .defaults
+interface SimpleTexture<P> {
+	(params?: P): Node<'vec3'>;
+	defaults: P;
+}
+
+// Texture with a .normal() method
+interface TextureWithNormal<P> {
+	(params?: P): Node<'vec3'>;
+	normal(params?: P): Node<'vec3'>;
+	defaults: P;
+}
+
+// Texture with an .opacity() method
+interface TextureWithOpacity<P> {
+	(params?: P): Node<'vec3'>;
+	opacity(params?: P): Node<'float'>;
+	defaults: P;
+}
+
+// runnyEggs: both .normal() and .roughness()
+interface RunnyEggsTexture {
+	(params?: RunnyEggsParams): Node<'vec3'>;
+	normal(params?: RunnyEggsParams): Node<'vec3'>;
+	roughness(params?: RunnyEggsParams): Node<'float'>;
+	defaults: RunnyEggsParams;
+}
+
+// === Exports ===
+
+export declare const brain: TextureWithNormal<BrainParams>;
+export declare const bricks: SimpleTexture<BricksParams>;
+export declare const camouflage: SimpleTexture<CamouflageParams>;
+export declare const caustics: SimpleTexture<CausticsParams>;
+export declare const caveArt: SimpleTexture<CaveArtParams>;
+export declare const circleDecor: SimpleTexture<CircleDecorParams>;
+export declare const circles: SimpleTexture<CirclesParams>;
+export declare const clouds: TextureWithOpacity<CloudsParams>;
+export declare const concrete: SimpleTexture<ConcreteParams>;
+export declare const cork: SimpleTexture<CorkParams>;
+export declare const crumpledFabric: SimpleTexture<CrumpledFabricParams>;
+export declare const dalmatianSpots: SimpleTexture<DalmatianSpotsParams>;
+export declare const darthMaul: SimpleTexture<DarthMaulParams>;
+export declare const dysonSphere: SimpleTexture<DysonSphereParams>;
+export declare const entangled: SimpleTexture<EntangledParams>;
+export declare const fordite: SimpleTexture<ForditeParams>;
+export declare const gasGiant: SimpleTexture<GasGiantParams>;
+export declare const grid: SimpleTexture<GridParams>;
+export declare const halftone: SimpleTexture<HalftoneParams>;
+export declare const isolayers: SimpleTexture<IsolayersParams>;
+export declare const isolines: SimpleTexture<IsolinesParams>;
+export declare const karstRock: SimpleTexture<KarstRockParams>;
+export declare const marble: SimpleTexture<MarbleParams>;
+export declare const neonLights: SimpleTexture<NeonLightsParams>;
+export declare const perlinNoise: SimpleTexture<PerlinNoiseParams>;
+export declare const photosphere: SimpleTexture<PhotosphereParams>;
+export declare const planet: SimpleTexture<PlanetParams>;
+export declare const polkaDots: SimpleTexture<PolkaDotsParams>;
+export declare const processedWood: SimpleTexture<ProcessedWoodParams>;
+export declare const protozoa: SimpleTexture<ProtozoaParams>;
+export declare const reticularVeins: SimpleTexture<ReticularVeinsParams>;
+export declare const romanPaving: SimpleTexture<RomanPavingParams>;
+export declare const rotator: TextureWithNormal<RotatorParams>;
+export declare const roughClay: SimpleTexture<RoughClayParams>;
+export declare const runnyEggs: RunnyEggsTexture;
+export declare const rust: TextureWithOpacity<RustParams>;
+export declare const satin: SimpleTexture<SatinParams>;
+export declare const scaler: TextureWithNormal<ScalerParams>;
+export declare const scepterHead: SimpleTexture<ScepterHeadParams>;
+export declare const scream: SimpleTexture<ScreamParams>;
+export declare const stars: SimpleTexture<StarsParams>;
+export declare const staticNoise: SimpleTexture<StaticNoiseParams>;
+export declare const supersphere: TextureWithNormal<SupersphereParams>;
+export declare const tigerFur: SimpleTexture<TigerFurParams>;
+export declare const translator: TextureWithNormal<TranslatorParams>;
+export declare const turbulentSmoke: SimpleTexture<TurbulentSmokeParams>;
+export declare const voronoiCells: SimpleTexture<VoronoiCellsParams>;
+export declare const waterDrops: SimpleTexture<WaterDropsParams>;
+export declare const watermelon: SimpleTexture<WatermelonParams>;
+export declare const waves: TextureWithOpacity<WavesParams>;
+export declare const wood: SimpleTexture<WoodParams>;
+export declare const zebraLines: SimpleTexture<ZebraLinesParams>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["es2020", "dom"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "tsl-textures": ["./src/tsl-textures.d.ts"]
+    }
+  },
+  "include": ["src/tsl-textures.d.ts", "src/tsl-textures-tests.ts"]
+}


### PR DESCRIPTION
I've been using some of the textures provided by this npm package in a hobby project that I recently converted to TypeScript. So, I would like to contribute type declarations for this package. 

Summary of changes:
- `src/tsl-textures.d.ts`: type declarations for everything this package exports: the texture exports, the utility functions, and the re-exported three/tsl noise helpers
- `src/tsl-textures-tests.ts`: a DefinitelyTyped-style test file (type-checked, never run) to catch regressions in the type declarations
- `.github/workflows/test.yml`: a small GitHub Actions workflow that runs the type check test on PRs and pushes to main
- `tsconfig.json`: added for config when running the type check test
- `package.json`: exports the declared types, adds three as a peer dependency, adds dev dependencies needed for running the type check test (`three`, `typescript`, and `@types/three`)
- `package-lock.json`: additions are a consequence of new dev dependencies

I'm happy to cut the scope (remove the CI and/or tests and new dev dependencies) if you prefer. Also, I understand if you'd prefer not to maintain typescript types, and am happy to submit this to DefinitelyTyped instead if you prefer.

Thank you for your work on this awesome project!